### PR TITLE
Placeholder talents, color alerts fixes, ru localization, delta- and gamma- codes commented

### DIFF
--- a/Blueshield Job/Language/English.xml
+++ b/Blueshield Job/Language/English.xml
@@ -4,7 +4,7 @@
   <jobname.blueshield>Blueshield Officer</jobname.blueshield>
   <jobdescription.blueshield>Dedicated to safeguarding ship captains and crew with unwavering commitment and expertise. A trusted guardian of maritime security.</jobdescription.blueshield>
  
-  <flashnuke.prime>Start Countdown (45s)</flashnuke.prime>
+  <gygax.flashbang>Shockwave</gygax.flashbang>
   <gygax.overload>Toggle Overload</gygax.overload>
   <gygax.taser>Pacifier</gygax.taser>
   <gygax.disabler>CH-PD Disabler</gygax.disabler>
@@ -13,6 +13,11 @@
 
 
   <!-- Items -->
+
+  <entityname.acidimplantdetonation>acid implant detonation</entityname.acidimplantdetonation>
+
+  <entityname.blueshieldoutfit>Blueshield Outfit</entityname.blueshieldoutfit>
+  <entityname.blueshieldoutfit>A comfortable blue uniform used by high-ranked professional bodyguards</entityname.blueshieldoutfit>
 
   <entityname.bsstunbaton>Trusted Stunbaton</entityname.bsstunbaton>
   <entitydescription.bsstunbaton>A trusty tool for a trustworthy officer</entitydescription.bsstunbaton>
@@ -33,7 +38,7 @@
   <entitydescription.implantdeathalarm>Whenever the person with this implant injected falls below 0 health or dies, every crewmate receives a notification (regardless of distance and radio channel) including current coordinates and hull name. </entitydescription.implantdeathalarm>
 
   <entityname.implantchemical>Chemical Implant</entityname.implantchemical>
-  <entitydescription.implantchemical>Upon subject death, explodes violently in a cloud of acid, damaging everyone around. Death is inevitable, so make it count.</entitydescription.implantchemical>
+  <entitydescription.implantchemical>Upon subject death, explodes violently in a cloud of acid, damaging everyone around. Everyone dies, so make it count.</entitydescription.implantchemical>
 
   <entityname.rescuehook>Rescue Hook</entityname.rescuehook>
   <entitydescription.rescuehook>Fires a harmless hook, quickly grabbing the target and then quickly retracting, allowing the wielder to rescue crewmates from danger with relative ease. Reusable</entitydescription.rescuehook>
@@ -60,6 +65,9 @@
   <entityname.unica>Mateba Model 6 Unica</entityname.unica>
   <entitydescription.unica>7-round rapid fire revolver for those times when you need real POWER. Ammo cannot be crafted, you should check your local military shops or wrecks. Crafted empty</entitydescription.unica>
 
+  <entityname.unicaround>Unica Round</entityname.unicaround>
+  <entitydescription.unicaround>A special bullet for a special firearm. Can only be found in wrecks and such, or bought at outposts</entitydescription.unicaround>
+
   <entityname.multirevolver>Multimode Energy Revolver</entityname.multirevolver>
   <multirevolver.ButtonLabelTaserMode>TASER</multirevolver.ButtonLabelTaserMode>
   <multirevolver.ButtonLabelDisablerMode>DISABLER</multirevolver.ButtonLabelDisablerMode>
@@ -81,29 +89,19 @@
   
 
   <entityname.commsterminal>Comms Terminal</entityname.commsterminal>
-  <entitydescription.commsterminal>Attach to a wall, then insert the auth key. Unlimited range, powered with internal battery</entitydescription.commsterminal>
+  <entitydescription.commsterminal>Attach to a wall, then insert the auth key. Unlimited range, powered with internal battery. Useless without the Blueshield Officer</entitydescription.commsterminal>
 
   <entityname.greenauthkey>Green Auth Key</entityname.greenauthkey>
   <entitydescription.greenauthkey>Green plastic card. When inserted in the comms terminal, boosts submarine movement speed, fabrication speed and deconstruction speed</entitydescription.greenauthkey>
 
   <entityname.blueauthkey>Blue Auth Key</entityname.blueauthkey>
-  <entitydescription.blueauthkey>Blue plastic card. When inserted in the comms terminal, boosts repair, welding and crew movement speed</entitydescription.blueauthkey>
+  <entitydescription.blueauthkey>Blue plastic card. When inserted in the comms terminal, boosts crew repair, welding and crew movement speed</entitydescription.blueauthkey>
 
   <entityname.redauthkey>Red Auth Key</entityname.redauthkey>
-  <entitydescription.redauthkey>Red plastic card. When inserted in the comms terminal, boosts crew damage resistance and damage</entitydescription.redauthkey>
-
-  <entityname.gammaauthkey>Gamma Auth Key</entityname.gammaauthkey>
-  <entitydescription.gammaauthkey>Yellow plastic card. When inserted in the comms terminal, allows usage of the Gygax mech</entitydescription.gammaauthkey>
-
-  <entityname.deltaauthkey>Delta Auth Key</entityname.deltaauthkey>
-  <entitydescription.deltaauthkey>Purple plastic card. When inserted in the comms terminal, allows usage of the flash nuke</entitydescription.deltaauthkey>
+  <entitydescription.redauthkey>Red plastic card. When inserted in the comms terminal, boosts crew damage resistance and damage, allows use of gygax weaponry</entitydescription.redauthkey>
 
   <entityname.gygax>Gygax</entityname.gygax>
-  <entitydescription.gygax>A powerful military mech, capable of withstanding extreme stress and moving with great speeds, but hard to make and only works during active gamma-code</entitydescription.gygax>
-
-  <entityname.flashnuke>Flash Nuke</entityname.flashnuke>
-  <entitydescription.flashnuke>An extremely powerful explosive pacification device. Blinds, stuns and deafens in a huge radius. Can only be used during code delta</entitydescription.flashnuke>
-
+  <entitydescription.gygax>A powerful military mech, capable of withstanding extreme stress and moving with great speeds, but hard to make and only capable of firing during active red code</entitydescription.gygax>
 
   <!-- Talent Trees -->
 
@@ -134,8 +132,8 @@
   <talentname.testinggrounds>Testing Grounds</talentname.testinggrounds>
 
   <talentname.learningtoswitchhands>How to Switch Hands?</talentname.learningtoswitchhands>
-  <talentdescription.learningtoswitchhandsrevolver>Withing [seconds] seconds after attacking with a pistol or revolver, your next attack with a stunning weapon is [damage]% more powerful</talentdescription.learningtoswitchhandsrevolver>
-  <talentdescription.learningtoswitchhandsstun>Withing [seconds] seconds after attacking with a stunning weapon, your next attack with a pistol or a revolver is [damage]% more powerful</talentdescription.learningtoswitchhandsstun>
+  <talentdescription.learningtoswitchhandsrevolver>Within [seconds] seconds after attacking with a pistol or revolver, your next attack with a stunning weapon is [damage]% more powerful</talentdescription.learningtoswitchhandsrevolver>
+  <talentdescription.learningtoswitchhandsstun>Within [seconds] seconds after attacking with a stunning weapon, your next attack with a pistol or a revolver is [damage]% more powerful</talentdescription.learningtoswitchhandsstun>
 
   <talentname.breathingtube>Breathing Tube, Sighing Tube...</talentname.breathingtube>
   <talentdescription.breathingtube>Using a breathing tube implant allows you to breathe when below 0 health if you are not underwater</talentdescription.breathingtube>
@@ -153,18 +151,18 @@
   <talentdescription.sleepcarp>When you are below 0 health, gain [amount]% damage resistance</talentdescription.sleepcarp>
 
   <talentname.laststand>The Last Stand</talentname.laststand>
-  <talentdescription.laststand>Inflict [amount] more damage with for every nearby enemy, if you are alone. Up to [maxamount]%</talentdescription.laststand>
+  <talentdescription.laststand>Inflict [amount]% more damage with for every nearby enemy, if you are alone. Up to [maxamount]%</talentdescription.laststand>
   <talentdescription.unicared>Unica ammo cannot be fabricated - only found or bought at military outposts</talentdescription.unicared>
   <talentdescription.unica>[text]</talentdescription.unica>
 
   <talentname.powbzzt>POW BZZZZT</talentname.powbzzt>
-  <talentdescription.powbzzt>The multirevolver has 3 modes - short stun, progressive slowdown and lethal. Lethal mode is only available during active red, gamma or delta codes. Charged inside battery-charging devices, make sure you have one.</talentdescription.powbzzt>
+  <talentdescription.powbzzt>The multirevolver has 3 modes - short stun, progressive slowdown and lethal. Lethal mode is only available during active red code. Charged inside battery-charging devices, make sure you have one.</talentdescription.powbzzt>
 
   <talentname.mindblock>Mindblock</talentname.mindblock>
   <talentdescription.mindblock>Mindshield implant makes a person permanently immune to psychosis and hallucinations</talentdescription.mindblock>
 
   <talentname.whysodark>Why So Dark?</talentname.whysodark>
-  <talentdescription.whysodark>Muffler headset protects one from sensory overload, and welding implants protect you from blindness - two effects of the stun grenade, violent grenade and flash nukes</talentdescription.whysodark>
+  <talentdescription.whysodark>Muffler headset protects one from sensory overload, and welding implants protect you from blindness - two effects of the stun grenade and violent grenades</talentdescription.whysodark>
 
   <talentname.trackerson>Trackers On!</talentname.trackerson>
   <talentdescription.trackerson>Every crewmate with a death alarm implant increases your speed by [speed]% and vitality by [vitality]%. Every crewmate without a death alarm implant gives you psychosis</talentdescription.trackerson>
@@ -183,19 +181,13 @@
   <talentdescription.codeextra>[text]</talentdescription.codeextra>
 
   <talentname.codegreen>Code 'Green'</talentname.codegreen>
-  <talentdescription.codegreen>Using the green auth key boosts submarine movement speed, fabrication speed and deconstruction speed by [amount]%</talentdescription.codegreen>
+  <talentdescription.codegreen>Using the green auth key boosts pump and engine speed by [pumpenginespeed]%, fabrication speed and deconstruction speed by [fabricatorspeed]%</talentdescription.codegreen>
 
   <talentname.codeblue>Code 'Blue'</talentname.codeblue>
-  <talentdescription.codeblue>Using the blue auth key boosts repair, welding and movement speed by [amount]%</talentdescription.codeblue>
+  <talentdescription.codeblue>Using the blue auth key boosts crew repair, welding and movement speed by [amount]%</talentdescription.codeblue>
 
   <talentname.codered>Code 'Red'</talentname.codered>
   <talentdescription.codered>Using the red auth key boosts crew damage resistance and damage by [amount]%</talentdescription.codered>
-
-  <talentname.codegamma>Code 'Gamma'</talentname.codegamma>
-  <talentdescription.codegamma>Using the omega auth key allows using the Gygax mech</talentdescription.codegamma>
-
-  <talentname.codedelta>Code 'Delta'</talentname.codedelta>
-  <talentdescription.codedelta>Using the delta auth key allows using the flash nuke</talentdescription.codedelta>
 
  <!-- Afflictions -->
 
@@ -207,12 +199,6 @@
 
   <afflictionname.codered>Code 'Red'</afflictionname.codered>
   <afflictiondescription.codered>You deal more damage and take less damage</afflictiondescription.codered>
-
-  <afflictionname.codegamma>Code 'Gamma'</afflictionname.codegamma>
-  <afflictiondescription.codegamma>Gygax mech : active</afflictiondescription.codegamma>
-
-  <afflictionname.codedelta>Code 'Delta'</afflictionname.codedelta>
-  <afflictiondescription.codedelta>Flash nuke : active</afflictiondescription.codedelta>
 
   <afflictionname.stunattack>Stunning Attack</afflictionname.stunattack>
   <afflictiondescription.stunattack>You made an attack with a stunning weapon, now shoot it!</afflictiondescription.stunattack>

--- a/Blueshield Job/Language/russian.xml
+++ b/Blueshield Job/Language/russian.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="utf-8"?>
+<infotexts language="English" nowhitespace="false" translatedname="English">
+ 
+  <jobname.blueshield>Офицер 'Синий Щит'</jobname.blueshield>
+  <jobdescription.blueshield>Посвятивший себя защите капитанов и экипажей судов от опасностей своей непоколебимой решимостью и опытом телохранитель. Надёжный защитник безопасности в суровых водах Европы.</jobdescription.blueshield>
+ 
+  <gygax.flashbang>Ударная волна</gygax.flashbang>
+  <gygax.overload>Перекл. перегрузку</gygax.overload>
+  <gygax.taser>Усмиритель</gygax.taser>
+  <gygax.disabler>CH-PD 'Оглушитель'</gygax.disabler>
+  <gygax.lethal>CH-PS 'Огненный дротик'</gygax.lethal>
+  <gygax.rescuehook>Спасательный крюк</gygax.rescuehook>
+
+
+  <!-- Items -->
+
+  <entityname.acidimplantdetonation>acid implant detonation</entityname.acidimplantdetonation>
+
+  <entityname.blueshieldoutfit>Униформа офицера 'Синий щит'</entityname.blueshieldoutfit>
+  <entityname.blueshieldoutfit>Удобная синяя униформа, используемая высокоранговыми профессиональными телохранителями</entityname.blueshieldoutfit>
+
+  <entityname.bsstunbaton>Надёжная оглушающая дубинка</entityname.bsstunbaton>
+  <entitydescription.bsstunbaton>Надёжное оружие надёжного офицера</entitydescription.bsstunbaton>
+
+  <entityname.europanlaw>Кодекс Европы</entityname.europanlaw>
+  <entitydescription.europanlaw>Книга, заполненная таинственными символами. Тяжелее, чем выглядит.</entitydescription.europanlaw>
+
+  <entityname.dogmask>Маска собаки</entityname.dogmask>
+  <entitydescription.dogmask>Лучше не надо, правда</entitydescription.dogmask>
+
+  <entityname.crewtracker>Трекер экипажа</entityname.crewtracker>
+  <entitydescription.crewtracker>Отображает имя, местонахождение, здоровье и примерное направление до каждого члена экипажа</entitydescription.crewtracker>
+
+  <entityname.bsimplanter>Имплантер</entityname.bsimplanter>
+  <entitydescription.bsimplanter>Специальный инъектор, предназначенный для внедрения некоторых имплантов</entitydescription.bsimplanter>
+
+  <entityname.implantdeathalarm>Имплант оповещения о смерти</entityname.implantdeathalarm>
+  <entitydescription.implantdeathalarm>Когда член экипажа с таким имплантом умирает или падает в критическое состояние, весь остальной экипаж получает оповещение об этом, содержащее текущие координаты и название отсека</entitydescription.implantdeathalarm>
+
+  <entityname.implantchemical>Химический имплант</entityname.implantchemical>
+  <entitydescription.implantchemical>При смерти носителя, взрывается облаком капель кислоты, нанося урон всему вокруг. Все умирают, так что уйдите красиво.</entitydescription.implantchemical>
+
+  <entityname.rescuehook>Спасательный крюк</entityname.rescuehook>
+  <entitydescription.rescuehook>Запускает безобидный крюк-липочку, цепляющуюся к поверхности при контакте и затем быстро втягивающуюся обратно в инструмент, позволяя носителю вытаскивать союзников из опасности с относительной простотой. Не требует боеприпасы</entitydescription.rescuehook>
+
+  <entityname.sleepgrenade>Усыпляющая граната</entityname.sleepgrenade>
+  <entitydescription.sleepgrenade>Медленно выпускает усыпляющий газ в воздух, замедляя и затем усыпляя всех, оказавшихся в области - и людей, и местную фауну. Ломается в воде, и каким-то образом усыпляет тех, кто в скафандре</entitydescription.sleepgrenade>
+
+  <entityname.boilinggrenade>Кипятящая граната</entityname.boilinggrenade>
+  <entitydescription.boilinggrenade>Будучи брошенной в воду, нагревает область вокруг себя с такой силой, что течение втягивает всё вокруг к центру. Не может быть потушена вручную, но выключается сама когда не находится в воде. Но даже тогда, она слишком горячая для взятия в руки даже в скафандре</entitydescription.boilinggrenade>
+
+  <entityname.violentgrenade>Светосиловая граната</entityname.violentgrenade>
+  <entitydescription.violentgrenade>При контакте со стеной или существом, взрывается с огромной силой, яркостью и громкостью, но не наносит травм или повреждений корпусу</entitydescription.violentgrenade>
+
+
+  <entityname.breathingtube>Дыхательная трубка</entityname.breathingtube>
+  <entitydescription.breathingtube>Будучи имплантированной, предотвращает удушение носителя если тот потерял сознание от низкого уровня здоровья, если он в противном случае мог бы дышать</entitydescription.breathingtube>
+
+  <entityname.sighingtube>Вздыхательная трубка</entityname.sighingtube>
+  <entitydescription.sighingtube>Именно это и делает</entitydescription.sighingtube>
+
+  <entityname.lsd>ЛСД</entityname.lsd>
+  <entitydescription.lsd>Уооооо ебать штырит</entitydescription.lsd>
+
+  <entityname.unica>Mateba Model 6 Unica</entityname.unica>
+  <entitydescription.unica>7-зарядный скорострельный револьвер для тех случаев, когда вам нужна настоящая МОЩЬ. Боеприпасы не могут быть созданы, вам стоит проведать местный магазин или обломки. Создаётся пустым</entitydescription.unica>
+
+  <entityname.unicaround>Пуля для Unica</entityname.unicaround>
+  <entitydescription.unicaround>Особая пуля для особого огнестрела. Могут быть найдены только в обломках и прочих заброшенных контейнерах, либо куплены на аванпосте</entitydescription.unicaround>
+
+  <entityname.multirevolver>Мультирежимный энергетический револьвер</entityname.multirevolver>
+  <multirevolver.ButtonLabelTaserMode>ШОКЕР</multirevolver.ButtonLabelTaserMode>
+  <multirevolver.ButtonLabelDisablerMode>НЕЙТРАЛИЗАТОР</multirevolver.ButtonLabelDisablerMode>
+  <multirevolver.ButtonLabelLethalMode>ЛЕТАЛЬНЫЙ</multirevolver.ButtonLabelLethalMode>
+
+
+  <entityname.implantmindshield>Имплант защиты разума</entityname.implantmindshield>
+  <entitydescription.implantmindshield>При внедрении, имплант самостоятельно достигает мозга и блокироует некоторые нейроны для предотвращения каких-либо внешних изменений. По какой-то причине, он ещё и повышает верность...</entitydescription.implantmindshield>
+
+  <entityname.implantweldingshield>Сварочный имплант</entityname.implantweldingshield>
+  <entitydescription.implantweldingshield>Особые глазные прозрачные щиты, предотвращающие урон по глазам, вызванный ярким светом</entitydescription.implantweldingshield>
+
+  <entityname.mufflerheadset>Шумоподавляющие наушники</entityname.mufflerheadset>
+  <entitydescription.mufflerheadset>Военные наушники с активным шумоподавлением</entitydescription.mufflerheadset>
+
+  <entityname.floppaportal>Межпространственный приёмник</entityname.floppaportal>
+  <entitydescription.floppaportal>Может передумаете?</entitydescription.floppaportal>
+
+  
+
+  <entityname.commsterminal>Терминал связи</entityname.commsterminal>
+  <entitydescription.commsterminal>Прикрепите к стене, затем внесите ключ аутентификации. Дальность не ограничена, работает на внутренней батарее. Бесполезен без офицера 'Синий щит'</entitydescription.commsterminal>
+
+  <entityname.greenauthkey>Зелёный ключ аутентификации</entityname.greenauthkey>
+  <entitydescription.greenauthkey>Зелёная пластиковая карта. При внесении в терминал связи, увеличивает скорость двигателей и насосов, а также скорость работы фабрикаторов и деконструкторов</entitydescription.greenauthkey>
+
+  <entityname.blueauthkey>Синий ключ аутентификации</entityname.blueauthkey>
+  <entitydescription.blueauthkey>Синяя пластиковая карта. При внесении в терминал связи, ускоряет скорость починки и передвижения всего экипажа</entitydescription.blueauthkey>
+
+  <entityname.redauthkey>Красный ключ аутентификации</entityname.redauthkey>
+  <entitydescription.redauthkey>Красная пластиковая карта. При внесении в терминал связи, увеличивает наносимый экипажем урон и уменьшает получаемый урон. Также позволяет использовать вооружение Гигакса и летальный режим мультирежимного револьвера</entitydescription.redauthkey>
+
+  <entityname.gygax>'Гигакс'</entityname.gygax>
+  <entitydescription.gygax>Мощный военный экзокостюм, способный выдержать значительную внешнюю нагрузку, а также перемещаться со значительной скоростью. Сложно создать, а также не может стрелять в любой код, кроме красного</entitydescription.gygax>
+
+  <!-- Talent Trees -->
+
+  <talenttree.onemanapocalypse>Человек-апокалипсис</talenttree.onemanapocalypse>
+  <talenttree.yourshield>Ваш щит</talenttree.yourshield>
+  <talenttree.accordingtoplan>В соответствии с планом</talenttree.accordingtoplan>
+
+  <!-- Talents -->
+
+  <talentname.glorytocoalition>Слава Коалиции</talentname.glorytocoalition>
+  <talentdescription.glorytocoalition>Получите одноразовую прибавку в виде [xpamount] опыта, а также [bonus] [skillmedical], [skillhelm] и [skillweapons] навыков после использования в общей сумме [requirement] медицинских предметов на союзников</talentdescription.glorytocoalition>
+  <talentdescription.glorytocoalition2>Торговцы Коалиции делают скидку в [amount]%</talentdescription.glorytocoalition2>
+
+  <talentname.stateyourlaws>Назови законы</talentname.stateyourlaws>
+  <talentdescription.stateyourlawsextrared>Наносит непоправимый ущерб социальному статусу</talentdescription.stateyourlawsextrared>
+  <talentdescription.stateyourlawsextra>[text]</talentdescription.stateyourlawsextra>
+
+  <talentname.totalsurveillance>Тотальная слежка</talentname.totalsurveillance>
+  <talentdescription.totalsurveillance>Отслеживайте ваших союзников с помощью специального планшета</talentdescription.totalsurveillance>
+
+  <talentname.dontdaredying>Только вздумай умереть</talentname.dontdaredying>
+  <talentdescription.dontdaredying>Когда член экипажа с имплантом оповещения о смерти умирает или входит в критическое состояние, все члены экипажа получают оповещение, включающее в себя его координаты и название отсека</talentdescription.dontdaredying>
+  <talentdescription.dontdaredying2>Когда член экипажа с химическим имплантом умирает, он взрывается облаком капель кислоты</talentdescription.dontdaredying2>
+
+  <talentname.medicaltools>Медицинские инструменты</talentname.medicaltools>
+  <talentdescription.medicaltools>Применяемый вами СЛР на [amount]% сильнее</talentdescription.medicaltools>
+
+  <talentname.testinggrounds>Полигон</talentname.testinggrounds>
+
+  <talentname.learningtoswitchhands>Как менять руки?</talentname.learningtoswitchhands>
+  <talentdescription.learningtoswitchhandsrevolver>В течении [seconds] секунд после атаки пистолетом или револьвером, ваша следующая атака оглушающим оружием наносит на [damage]% больше урона</talentdescription.learningtoswitchhandsrevolver>
+  <talentdescription.learningtoswitchhandsstun>В течении [seconds] секунд после атаки оглушающим оружием, ваша следующая атака пистолетом или револьвером наносит на [damage]% больше урона</talentdescription.learningtoswitchhandsstun>
+
+  <talentname.breathingtube>Дыхательная трубка, вздыхательная трубка..</talentname.breathingtube>
+  <talentdescription.breathingtube>Использование импланта дыхательной трубки позволяет носителю дышать когда он находится в критическом состоянии, но только если он не в воде и вокруг есть воздух</talentdescription.breathingtube>
+
+  <talentname.bsselfcare>Самолечение</talentname.bsselfcare>
+  <talentdescription.bsselfcare>Медицинские препараты, применяемые на вас, на [amount]% эффективнее</talentdescription.bsselfcare>
+
+  <talentname.officerdrunkshield>Офицер 'Пьяный щит'</talentname.officerdrunkshield>
+  <talentdescription.officerdrunkshield>Будучи пьяным, вы получаете на [amount]% меньше урона</talentdescription.officerdrunkshield>
+
+  <talentname.adrenalinepump>Адреналиновая помпа</talentname.adrenalinepump>
+  <talentdescription.adrenalinepump>Когда ваше здоровье падает ниже 0, вы остаётесь в сознании ещё на [time] секунд, но замедляетесь на [slowdown]%</talentdescription.adrenalinepump>
+
+  <talentname.sleepcarp>Путь Спящего Карпа</talentname.sleepcarp>
+  <talentdescription.sleepcarp>Когда ваше здоровье ниже 0 health, вы получаете на [amount]% меньше урона</talentdescription.sleepcarp>
+
+  <talentname.laststand>Последняя битва</talentname.laststand>
+  <talentdescription.laststand>Вы наносите на [amount]% больше урона за каждого врага рядом, если вы одни. Максимум [maxamount]%</talentdescription.laststand>
+  <talentdescription.unicared>Боеприпасы для Unica не могут быть созданы - только найдены или куплены</talentdescription.unicared>
+  <talentdescription.unica>[text]</talentdescription.unica>
+
+  <talentname.powbzzt>ПЫЩ БЗЗЗТ</talentname.powbzzt>
+  <talentdescription.powbzzt>Мультиревольвер имеет 3 режима - короткое оглушение, постепенное замедление и летальный. Летальный режим доступен только при активном красном коде. Заряжается в заряжающих батареи устройствах, убедитесь что у вас такие есть.</talentdescription.powbzzt>
+
+  <talentname.mindblock>Блокировка мозгов</talentname.mindblock>
+  <talentdescription.mindblock>Имплант защиты разума делает носителя навсегда устойчивым к психозу, галлюцинациям и схожим эффектам</talentdescription.mindblock>
+
+  <talentname.whysodark>Кто выключил свет?</talentname.whysodark>
+  <talentdescription.whysodark>Наушники с шумоподавлением защищают от звуков, а имплант сварочных щитов защищает от слепоты - двух эффектов светошумовых и светосиловых гранат</talentdescription.whysodark>
+
+  <talentname.trackerson>Включите датчики!</talentname.trackerson>
+  <talentdescription.trackerson>Каждый член экипажа с имплантом оповещения о смерти увеличивает вашу скорость на [speed]%, а здоровье - на [vitality]%. Каждый член экипажа без импланта оповещения о смерти даёт вам психоз</talentdescription.trackerson>
+
+  <talentname.captainyouthere>Капитан, вы там?</talentname.captainyouthere>
+  <talentdescription.captainyouthere>Вы двигаетесь на [speed]% быстрее за каждого бессознательного члена экипажа. Вплоть до [speedmax]%.</talentdescription.captainyouthere>
+
+  <talentname.warcrimes>Военные преступления</talentname.warcrimes>
+  <talentdescription.warcrimes>Что за ужасы оно нам принесёт?</talentdescription.warcrimes>
+
+  <talentname.calltheshuttle>Вызывайте шаттл!</talentname.calltheshuttle>
+  <talentdescription.calltheshuttle>Если ни один член экипажа не умер во время миссии, получите [moneybonus] марок и [xpbonus] опыта</talentdescription.calltheshuttle>
+
+
+  <talentdescription.codeextrared>Одновременно может быть активен только один код!</talentdescription.codeextrared>
+  <talentdescription.codeextra>[text]</talentdescription.codeextra>
+
+  <talentname.codegreen>Зелёный код</talentname.codegreen>
+  <talentdescription.codegreen>Использование зелёного ключа аутенификации увеличивает силу насосов и двигателя на [pumpenginespeed]%, а также скорость фабрикаторов и деконструкторов на [fabricatorspeed]%</talentdescription.codegreen>
+
+  <talentname.codeblue>Синий код</talentname.codeblue>
+  <talentdescription.codeblue>Использование синего ключа аутентификации увеличивает скорость передвижения экипажа и скорость починки на [amount]%</talentdescription.codeblue>
+
+  <talentname.codered>Красный код</talentname.codered>
+  <talentdescription.codered>Использование красного ключа аутентификации увеличивает урон, наносимый экипажем, и уменьшает урон, получаемый экипажем, на [amount]%</talentdescription.codered>
+
+ <!-- Afflictions -->
+
+  <afflictionname.codegreen>Зелёный код</afflictionname.codegreen>
+  <afflictiondescription.codegreen>Скорость подлодки и сборки/разборки предметов увеличена</afflictiondescription.codegreen>
+
+  <afflictionname.codeblue>Синий код</afflictionname.codeblue>
+  <afflictiondescription.codeblue>Скорость перемещения экипажа и скорость починки увеличена</afflictiondescription.codeblue>
+
+  <afflictionname.codered>Красный код</afflictionname.codered>
+  <afflictiondescription.codered>Увеличен наносимый и уменьшен получаемый урон</afflictiondescription.codered>
+
+  <afflictionname.stunattack>Оглушающая атака</afflictionname.stunattack>
+  <afflictiondescription.stunattack>Вы атаковали оглушающим оружием, теперь стреляйте!</afflictiondescription.stunattack>
+
+  <afflictionname.pistolattack>Выстрел из пистолета</afflictionname.pistolattack>
+  <afflictiondescription.pistolattack>Вы выстрелили из пистолета, теперь оглушите!</afflictiondescription.pistolattack>
+
+  <afflictionname.adrenalinepump>Адреналиновая помпа</afflictionname.adrenalinepump>
+  <afflictiondescription.adrenalinepump>Ваше тело всё ещё движется, хотя не должно</afflictiondescription.adrenalinepump>
+
+  <afflictionname.sleepcarp>Путь Спящего Карпа</afflictionname.sleepcarp>
+  <afflictiondescription.sleepcarp>Вы цепляетесь за свою жизнь, переживая атаки, которые должны были вас убить</afflictiondescription.sleepcarp>
+
+  <afflictionname.captainyouthere>Операция по спасению</afflictionname.captainyouthere>
+  <afflictiondescription.captainyouthere>Ваш напарник в беде, нужно спешить</afflictiondescription.captainyouthere>
+
+  <afflictionname.lsd>ЛСД</afflictionname.lsd>
+  <afflictiondescription.lsd>Уоооооо</afflictiondescription.lsd>
+
+  <afflictionname.sleepgrenade>Усыплён</afflictionname.sleepgrenade>
+  <afflictiondescription.sleepgrenade>Сладких снов</afflictiondescription.sleepgrenade>
+
+  <afflictionname.deathalarm>Оповещение о смерти</afflictionname.deathalarm>
+
+  <afflictionname.mindshield>Твёрд разумом</afflictionname.mindshield>
+
+  <afflictionname.weldingshield>Глаза защищены</afflictionname.weldingshield>
+  
+  <afflictionname.chemicalimplant>Химический имплант</afflictionname.chemicalimplant>
+  
+  <afflictionname.soultaint>Запятнанная душа</afflictionname.soultaint>
+  <afflictiondescription.soultaint>Вас предупреждали</afflictiondescription.soultaint>
+
+  <afflictionname.lawenforcement>Рука закона</afflictionname.lawenforcement>
+  <afflictiondescription.lawenforcement>Законное требование делает вас на 20% более восприимчивыми к урону</afflictiondescription.lawenforcement>
+
+  <afflictionname.breathingtube>Дыхательная трубка</afflictionname.breathingtube>
+
+  <afflictionname.disablerslow>Нет сил</afflictionname.disablerslow>
+  <afflictiondescription.disablerslow>Мышцы онемели и болят одновременно</afflictiondescription.disablerslow>
+
+  <afflictionname.floppabuff>Божественное вмешательство</afflictionname.floppabuff>
+
+  <afflictionname.gygaxoverload>Перегрузка актуаторов</afflictionname.gygaxoverload>
+  <afflictiondescription.gygaxoverload>ГЛОТАЙ ПЫЛЬ!</afflictiondescription.gygaxoverload>
+
+</infotexts>

--- a/Blueshield Job/XML/afflictions.xml
+++ b/Blueshield Job/XML/afflictions.xml
@@ -27,17 +27,6 @@
 
   <Affliction identifier="chemicalimplant" type="implant" limbspecific="false" indicatorlimb="Torso" showinhealthscannerthreshold="1" showiconthreshold="100" maxstrength="10"
     HealableInMedicalClinic="false">
-    <Effect minstrength="0" maxstrength="10">
-      <StatusEffect target="Character">
-        <Conditional isDead="true" disabledeltatime="true"/>
-        <Explosion range="500" ballastfloradamage="0" itemdamage="0" force="1" sparks="false" shockwave="false" flames="false" smoke="false" flash="false">
-          <Affliction identifier="acidburn" strength="150" />
-          <Affliction identifier="acidburn" strength="50" probability="0.2" dividebylimbcount="false" />
-          <Affliction identifier="stun" strength="0.5" />
-        </Explosion>
-        <SpawnItem identifier="acidmistemitter" count="10" aimspread="360" impulse="30" rotationtype="Collider" rotation="0" spawnposition="This" />
-      </StatusEffect>
-    </Effect>
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="0,0,1,1" origin="0.5,0.5" />
   </Affliction>
 
@@ -55,8 +44,8 @@
   <Affliction identifier="codegreen" type="buff" showbarinhealthmenu="false" iconcolors="0,200,50" limbspecific="false" indicatorlimb="Head" showinhealthscannerthreshold="1" showiconthreshold="1"
     maxstrength="10" HealableInMedicalClinic="false">
     <Effect minstrength="0" maxstrength="10">
-      <StatValue stattype="DeconstructorSpeedMultiplier" value="0.2" />
-      <StatValue stattype="FabricationSpeed" value="0.2" />
+      <StatValue stattype="DeconstructorSpeedMultiplier" value="0.5" />
+      <StatValue stattype="FabricationSpeed" value="0.5" />
     </Effect>
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="0,0,128,128" origin="0.5,0.5" />
   </Affliction>
@@ -65,10 +54,9 @@
     maxstrength="10"
     HealableInMedicalClinic="false">
     <Effect minstrength="0" maxstrength="10">
-      <StatValue stattype="AttackMultiplier" value="0.2" />
-      <StatValue stattype="MovementSpeed" value="0.2" />
-      <StatValue stattype="RepairSpeed" value="0.2" />
-      <StatValue stattype="RepairToolStructureRepairMultiplier" value="0.2" />
+      <StatValue stattype="MovementSpeed" value="0.3" />
+      <StatValue stattype="RepairSpeed" value="0.3" />
+      <StatValue stattype="RepairToolStructureRepairMultiplier" value="0.3" />
     </Effect>
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="0,0,128,128" origin="0.5,0.5" />
   </Affliction>
@@ -82,6 +70,7 @@
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="0,0,128,128" origin="0.5,0.5" />
   </Affliction>
 
+<!-- 
   <Affliction identifier="codegamma" type="buff" showbarinhealthmenu="false" iconcolors="255,150,0" limbspecific="false" indicatorlimb="Head" showinhealthscannerthreshold="1" showiconthreshold="1"
     maxstrength="10"
     HealableInMedicalClinic="false">
@@ -95,6 +84,7 @@
     <Effect minstrength="0" maxstrength="10" />
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="0,0,128,128" origin="0.5,0.5" />
   </Affliction>
+-->
 
   <Affliction identifier="stunattack" type="buff" limbspecific="false" indicatorlimb="Torso" showinhealthscannerthreshold="500" showiconthreshold="1" maxstrength="9" HealableInMedicalClinic="false">
     <Effect minstrength="0" maxstrength="9" />
@@ -223,4 +213,50 @@
       minspeedmultiplier="1" maxspeedmultiplier="0.05" />
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="128,384,128,128" origin="0.5,0.5" />
   </Affliction>
+
+    <Affliction
+    identifier="precodegreen"
+    nameidentifier="precodegreen"
+    type="talentbuff"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="1"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    iconcolors="0,0,0">
+    <Icon texture="Content/UI/TalentsIcons4.png" sheetindex="2,3" sheetelementsize="128,128" color="10,193,114,255" origin="0,0" />
+  </Affliction>
+
+    <Affliction
+    identifier="precodeblue"
+    nameidentifier="precodeblue"
+    type="talentbuff"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="1"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    iconcolors="0,0,0">
+    <Icon texture="Content/UI/TalentsIcons4.png" sheetindex="2,3" sheetelementsize="128,128" color="10,193,114,255" origin="0,0" />
+  </Affliction>
+
+    <Affliction
+    identifier="precodered"
+    nameidentifier="precodered"
+    type="talentbuff"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="1"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    iconcolors="0,0,0">
+    <Icon texture="Content/UI/TalentsIcons4.png" sheetindex="2,3" sheetelementsize="128,128" color="10,193,114,255" origin="0,0" />
+  </Affliction>
+
 </Afflictions>

--- a/Blueshield Job/XML/afflictions.xml
+++ b/Blueshield Job/XML/afflictions.xml
@@ -158,14 +158,14 @@
 
   <Affliction identifier="trackerson" type="buff" limbspecific="false" indicatorlimb="Head" showinhealthscannerthreshold="500" showiconthreshold="500" maxstrength="15" HealableInMedicalClinic="false">
     <Effect minstrength="0" maxstrength="16"
-      minspeedmultiplier="0" maxspeedmultiplier="0.5" minvitalitydecrease="0" maxvitalitydecrease="0.6" />
+      minspeedmultiplier="1" maxspeedmultiplier="1.5" minvitalitydecrease="0" maxvitalitydecrease="0.6" />
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="256,1128,128,128" origin="0.5,0.5" />
   </Affliction>
 
   <Affliction identifier="captainyouthere" type="buff" limbspecific="false" indicatorlimb="Head" showinhealthscannerthreshold="500" showiconthreshold="1" maxstrength="4"
     HealableInMedicalClinic="false">
     <Effect minstrength="0" maxstrength="4"
-      minspeedmultiplier="0" maxspeedmultiplier="0.4" />
+      minspeedmultiplier="1" maxspeedmultiplier="1.4" />
     <icon texture="%moddir%/Sprites/afflictionicons.png" sourcerect="384,128,128,128" origin="0.5,0.5" />
   </Affliction>
 

--- a/Blueshield Job/XML/items.xml
+++ b/Blueshield Job/XML/items.xml
@@ -235,6 +235,23 @@
     <Body width="3" height="7" density="11" />
   </Item>
 
+  <Item identifier="acidimplantdetonation" hideinmenus="true" Tags="smallitem,explosive,demolitionsexpert" Scale="0.5">
+    <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="0,0,1,1" depth="0.55" origin="0.5,0.5" />
+    <Body width="5" height="5" density="30" />
+    <ItemComponent>
+      <StatusEffect type="Always" target="This">
+        <SpawnItem identifier="acidmistemitter" count="10" aimspread="360" impulse="30" rotationtype="Collider" rotation="0" spawnposition="This" />
+        <sound file="Content/Sounds/Damage/Gore8.ogg" />
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnNotContained" target="NearbyCharacters" range="600" oneshot="true">
+        <Affliction identifier="acidburn" strength="30" />
+        <Affliction identifier="acidburn" strength="15" probability="0.2" dividebylimbcount="false" />
+        <Affliction identifier="stun" strength="0.5" />
+        <Remove />
+      </StatusEffect>
+    </ItemComponent>
+  </Item>
 
   <Item identifier="sleepgrenade" category="Weapon" Tags="smallitem,weapon,explosive,demolitionsexpert,handgrenade" maxstacksize="32" maxstacksizecharacterinventory="8"
     cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_soft">
@@ -419,8 +436,10 @@
         </StatusEffect>
         <StatusEffect type="OnUse" target="Character" comparison="or" delay="0.05">
           <Conditional codered="gte 1" />
+          <!-- 
           <Conditional codedelta="gte 1" />
           <Conditional codegamma="gte 1" />
+          -->
           <SpawnItem identifiers="multirevolverlethal_proj" spawnposition="ThisInventory" />
         </StatusEffect>
       </Button>
@@ -605,10 +624,18 @@
   </Item>
 
 
-  <Item name="unicaround" identifier="unicaround" category="Equipment" Tags="smallitem" maxstacksize="7" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_soft">
+  <Item identifier="unicaround" category="Equipment" Tags="smallitem" maxstacksize="7" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_soft">
     <Sprite texture="%moddir%/Sprites/spritesheet.png" sourcerect="388,178,50,20" origin="0.5,0.5" />
     <PreferredContainer secondary="wreckarmcab,abandonedarmcab,piratearmcab" minamount="4" maxamount="8" spawnprobability="0.3" />
     <PreferredContainer primary="secarmcab" />
+    <Price baseprice="50">
+      <Price storeidentifier="merchantoutpost" multiplier="1.5" minavailable="3" />
+      <Price storeidentifier="merchantcity" multiplier="1.25" minavailable="0" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="0" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="5" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" minavailable="3" />
+      <Price storeidentifier="merchantarmory" multiplier="0.9" minavailable="3" />
+    </Price>
     <Body width="34" height="14" density="30" />
     <Pickable slots="Any" msg="ItemMsgPickUpSelect" />
     <Projectile characterusable="false" hitscan="true" removeonhit="true">
@@ -632,6 +659,13 @@
 
   <Item identifier="lsd" category="Equipment" Tags="smallitem" maxstacksize="1" cargocontaineridentifier="metalcrate" scale="0.200" useinhealthinterface="true" impactsoundtag="impact_soft">
     <Sprite texture="%moddir%/Sprites/spritesheet.png" sourcerect="301,153,64,64" origin="0.5,0.5" />
+    <Price baseprice="150" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="0.85" />
+      <Price storeidentifier="merchantcity" multiplier="0.85" />
+      <Price storeidentifier="merchantresearch" sold="true" multiplier="1.2" minavailable="2" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" />
+      <Price storeidentifier="merchantmine" multiplier="0.85" />
+    </Price>
     <Fabricate suitablefabricators="medicalfabricator" requiredtime="2" requiresrecipe="true">
       <RequiredSkill identifier="medical" level="10" />
       <RequiredItem identifier="alienblood" />
@@ -683,28 +717,41 @@
 
       <StatusEffect type="Always" target="NearbyCharacters" range="100000" interval="5">
         <RequiredItems items="greenauthkey" type="Contained" />
-        <Affliction identifier="codegreen" amount="100" />
+        <Affliction identifier="precodegreen" amount="100" />
         <ReduceAffliction identifier="codeblue" amount="100" />
         <ReduceAffliction identifier="codered" amount="100" />
+        <ReduceAffliction identifier="precodeblue" amount="100" />
+        <ReduceAffliction identifier="precodered" amount="100" />
+        <!-- 
         <ReduceAffliction identifier="codegamma" amount="100" />
         <ReduceAffliction identifier="codedelta" amount="100" />
+        -->
       </StatusEffect>
       <StatusEffect type="Always" target="NearbyCharacters" range="100000" interval="5">
         <RequiredItems items="blueauthkey" type="Contained" />
-        <Affliction identifier="codeblue" amount="100" />
+        <Affliction identifier="precodeblue" amount="100" />
         <ReduceAffliction identifier="codegreen" amount="100" />
         <ReduceAffliction identifier="codered" amount="100" />
+        <ReduceAffliction identifier="precodegreen" amount="100" />
+        <ReduceAffliction identifier="precodered" amount="100" />
+        <!-- 
         <ReduceAffliction identifier="codegamma" amount="100" />
         <ReduceAffliction identifier="codedelta" amount="100" />
+        -->
       </StatusEffect>
       <StatusEffect type="Always" target="NearbyCharacters" range="100000" interval="5">
         <RequiredItems items="redauthkey" type="Contained" />
-        <Affliction identifier="codered" amount="100" />
+        <Affliction identifier="precodered" amount="100" />
         <ReduceAffliction identifier="codegreen" amount="100" />
         <ReduceAffliction identifier="codeblue" amount="100" />
+        <ReduceAffliction identifier="precodegreen" amount="100" />
+        <ReduceAffliction identifier="precodeblue" amount="100" />
+        <!-- 
         <ReduceAffliction identifier="codegamma" amount="100" />
         <ReduceAffliction identifier="codedelta" amount="100" />
+        -->
       </StatusEffect>
+      <!-- 
       <StatusEffect type="Always" target="NearbyCharacters" range="100000" interval="5">
         <RequiredItems items="gammaauthkey" type="Contained" />
         <Affliction identifier="codegamma" amount="100" />
@@ -721,6 +768,7 @@
         <ReduceAffliction identifier="codered" amount="100" />
         <ReduceAffliction identifier="codegamma" amount="100" />
       </StatusEffect>
+      -->
       <StatusEffect type="Always" target="Contained" condition="-10" interval="0.5" delay="0.05" disabledeltatime="true">
         <Use />
       </StatusEffect>
@@ -782,7 +830,7 @@
   </Item>
 
 
-  <Item name="" identifier="mufflerheadset" scale="0.5" category="Equipment" tags="smallitem,mobileradio" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
+  <Item identifier="mufflerheadset" scale="0.5" category="Equipment" tags="smallitem,mobileradio" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
     <InventoryIcon texture="%moddir%/Sprites/spritesheet.png" sourcerect="620,57,64,64" origin="0.5,0.5" />
     <Sprite name="Muffler Headset" texture="%moddir%/Sprites/spritesheet.png" depth="0.6" sourcerect="623,0,60,50" origin="0.5,0.5" />
     <Body radius="20" height="20" density="15" />
@@ -835,7 +883,7 @@
     <Holdable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="-10,0" holdangle="90" aimpos="45,0" aimangle="90" aimable="true">
       <StatusEffect type="OnUse" target="This" targetcomponent="LightComponent" condition="0" setvalue="true" isOn="true">
         <Conditional condition="gt 99" />
-        <Sound file="%ModDir%/Sounds/codegreen.ogg" range="500000" loop="false" />
+        <Sound file="%ModDir%/Sounds/codegreen.ogg" range="500000" loop="false" dontmuffle="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="10" />
     </Holdable>
@@ -856,7 +904,7 @@
     <Holdable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="-10,0" holdangle="90" aimpos="45,0" aimangle="90" aimable="true">
       <StatusEffect type="OnUse" target="This" targetcomponent="LightComponent" condition="0" setvalue="true" isOn="true">
         <Conditional condition="gt 99" />
-        <Sound file="%ModDir%/Sounds/coderedblue.ogg" range="500000" loop="false" />
+        <Sound file="%ModDir%/Sounds/coderedblue.ogg" range="500000" loop="false" dontmuffle="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="10" />
     </Holdable>
@@ -876,13 +924,13 @@
     <Holdable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="-10,0" holdangle="90" aimpos="45,0" aimangle="90" aimable="true">
       <StatusEffect type="OnUse" target="This" targetcomponent="LightComponent" condition="0" setvalue="true" isOn="true">
         <Conditional condition="gt 99" />
-        <Sound file="%ModDir%/Sounds/coderedblue.ogg" range="500000" loop="false" />
+        <Sound file="%ModDir%/Sounds/codegamma.ogg" range="500000" loop="false" dontmuffle="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="10" />
     </Holdable>
   </Item>
 
-
+  <!-- 
   <Item identifier="gammaauthkey" category="Equipment" HideConditionBar="true" Tags="smallitem,authkey" maxstacksize="1" cargocontaineridentifier="metalcrate" scale="1" impactsoundtag="impact_soft">
     <InventoryIcon texture="%moddir%/Sprites/spritesheet.png" sourcerect="240,708,97,79" origin="0.5,0.5" />
     <Sprite texture="%moddir%/Sprites/spritesheet.png" sourcerect="30,733,15,4" origin="0.5,0.5" />
@@ -896,7 +944,7 @@
     <Holdable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="-10,0" holdangle="90" aimpos="45,0" aimangle="90" aimable="true">
       <StatusEffect type="OnUse" target="This" targetcomponent="LightComponent" condition="0" setvalue="true" isOn="true">
         <Conditional condition="gt 99" />
-        <Sound file="%ModDir%/Sounds/codegamma.ogg" range="500000" loop="false" />
+        <Sound file="%ModDir%/Sounds/codegamma.ogg" range="500000" loop="false" dontmuffle="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="10" />
     </Holdable>
@@ -916,20 +964,20 @@
     <Holdable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="-10,0" holdangle="90" aimpos="45,0" aimangle="90" aimable="true">
       <StatusEffect type="OnUse" target="This" targetcomponent="LightComponent" condition="0" setvalue="true" isOn="true">
         <Conditional condition="gt 99" />
-        <Sound file="%ModDir%/Sounds/codedelta.ogg" range="500000" loop="false" />
-        
+        <Sound file="%ModDir%/Sounds/codedelta.ogg" range="500000" loop="false" dontmuffle="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="10" />
     </Holdable>
   </Item>
+-->
 
-
-  <Item name="" identifier="gygax" category="Diving,Equipment" tags="diving,deepdiving,deepdivinglarge,human" scale="0.5" fireproof="true" description="" isshootable="true"
+  <Item identifier="gygax" category="Diving,Equipment" tags="diving,deepdiving,deepdivinglarge,human" scale="0.5" fireproof="true" isshootable="true"
     allowdroppingonswapwith="diving" impactsoundtag="impact_metal_heavy" botpriority="0.5" cargocontaineridentifier="">
     <Deconstruct time="30">
       <Item identifier="rescuehook" />
       <Item identifier="titaniumaluminiumalloy" amount="5" />
       <Item identifier="fulgurium" amount="2" />
+      <RequiredItem identifier="multirevolver" amount="1" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="45" requiresrecipe="true">
       <RequiredSkill identifier="mechanical" level="30" />
@@ -937,7 +985,7 @@
       <RequiredItem identifier="titaniumaluminiumalloy" amount="8" />
       <RequiredItem identifier="fulgurium" amount="3" />
       <RequiredItem identifier="chitin" amount="4" />
-      <RequiredItem identifier="blueshieldoutfit" amount="1" />
+      <RequiredItem identifier="multirevolver" amount="1" />
       <RequiredItem identifier="rescuehook" amount="1" />
     </Fabricate>
     <InventoryIcon texture="%ModDir%/Sprites/gygax.png" sourcerect="907,902,80,80" origin="0.5,0.5" />
@@ -977,7 +1025,7 @@
         inheritorigin="false" origin="0.2,0.5" inheritsourcerect="false" sourcerect="0,0,1,1" />
       <sprite name="Gygax Exosuit Right Shoe Null" texture="%ModDir%/Sprites/gygax.png" limb="RightFoot" sound="footstep_armor_heavy" hidelimb="true" inherittexturescale="true"
         hideotherwearables="true" inheritorigin="false" origin="0.2,0.5" inheritsourcerect="false" sourcerect="0,0,1,1" />
-      <StatusEffect type="OnWearing" target="Character" UseHullOxygen="true" />
+      <StatusEffect type="OnWearing" target="Character" OxygenAvailable="1000.0" UseHullOxygen="false" />
       <StatusEffect type="OnWearing" target="Character" HideFace="true" ObstructVisionAmount="0.5" PressureProtection="70000.0" setvalue="true" disabledeltatime="true">
         <Sound file="Content/Items/Diving/DivingSuitLoop1.ogg" range="500" loop="true" />
         <Sound file="Content/Items/Diving/DivingSuitLoop2.ogg" range="500" loop="true" />
@@ -1019,13 +1067,38 @@
       <StatValue stattype="FlowResistance" value="1" />
       <StatValue stattype="PropulsionSpeed" value="-0.7" />
       <StatusEffect type="OnWearing" target="Character" LowPassMultiplier="0.2" setvalue="true" disabledeltatime="true" />
+      <StatusEffect type="OnWearing" target="This" condition="35" AllowWhenBroken="true">
+        <Conditional condition="lt 100" />
+      </StatusEffect>
     </Wearable>
     <StatusHUD drawhudwhenequipped="true" />
     <Holdable slots="OuterClothes+RightHand" controlpose="true" aimpos="70,5" handle1="-25,-7" />
 
     <CustomInterface canbeselected="false" drawhudwhenequipped="true" allowuioverlap="true">
       <GuiFrame relativesize="0.15,0.4" anchor="bottomright" pivot="bottomright" relativeoffset="0,0.1" style="ItemUI" />
-      <Button text="overload" connection="signal_out1">
+      <Button text="gygax.flashbang" connection="signal_out1">
+        <StatusEffect type="OnUse" target="This,Character" disabledeltatime="true" comparison="and">
+          <Conditional condition="eq 100" />
+          <Conditional voltage="gt 0.5" />
+          <sound file="Content/Items/Weapons/TrueStunGrenade.ogg" range="1500" />
+          <Explosion range="2000.0" force="200.0" shockwave="true" flames="false" smoke="true" underwaterBubble="false" sparks="false">
+            <Affliction identifier="stun" strength="1" />
+            <Affliction identifier="sensoryoverload" strength="100" />
+            <Affliction identifier="blind" strength="100" />
+          </Explosion>
+          <Explosion range="500.0" force="100.0" flames="false" underwaterBubble="false">
+            <Affliction identifier="stun" strength="3" />
+            <Affliction identifier="blind_hard" strength="100" />
+          </Explosion>
+        </StatusEffect>
+        <StatusEffect type="OnUse" target="Contained" targetslot="0" condition="-25">
+          <Conditional TargetContainer="true" condition="eq 100" />
+        </StatusEffect>
+        <StatusEffect type="OnUse" target="This" condition="0" setvalue="true">
+          <Conditional condition="eq 100" />
+        </StatusEffect>
+      </Button>
+      <Button text="gygax.overload" connection="signal_out1">
         <StatusEffect type="OnUse" target="Character" disabledeltatime="true" delay="0.05">
           <Conditional gygaxoverload="lt 1" />
           <Affliction identifier="gygaxoverload" amount="60" />
@@ -1093,17 +1166,19 @@
         <RequiredItems items="rescuehook_proj" type="Contained" />
         <Sound file="Content/Items/Weapons/HarpoonGun1.ogg" type="OnUse" range="1000" />
       </StatusEffect>
-      <!-- Enable when gamma -->
+      <!-- Enable when red -->
       <StatusEffect type="OnWearing" target="This,Character" isshootable="true" setvalue="true" interval="0.5" disabledeltatime="true">
-        <Conditional codegamma="gte 1" />
+        <Conditional codered="gte 1" />
       </StatusEffect>
       <!-- Otherwise disable -->
       <StatusEffect type="OnWearing" target="This,Character" isshootable="false" setvalue="true" interval="0.5" disabledeltatime="true">
-        <Conditional codegamma="lt 1" />
+        <Conditional codered="lt 1" />
       </StatusEffect>
     </RangedWeapon>
     <aitarget maxsightrange="1500" sonarlabel="GYGAX" SoundRange="50000" />
   </Item>
+
+  <!-- No red? 
 
   <Item identifier="flashnuke" category="Equipment" Tags="smallitem" maxstacksize="1" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_soft">
     <Sprite texture="%moddir%/Sprites/spritesheet.png" sourcerect="937,896,87,128" origin="0.5,0.5" />
@@ -1125,9 +1200,7 @@
       <StatusEffect type="OnUse" target="This" IsOn="true" duration="45">
         <sound file="%ModDir%/Sounds/codedelta.ogg" range="5000.0" loop="true" volume="0.5" />
       </StatusEffect>
-      <!-- Self-destruction after 45 seconds-->
       <StatusEffect type="OnUse" target="This" IsOn="false" delay="45" setvalue="true" condition="-200" />
-      <!-- Effects when taking damage-->
       <StatusEffect type="OnBroken" target="this">
         <sound file="Content/Items/Weapons/TrueStunGrenade.ogg" volume="4" range="5000" dontmuffle="true" />
         <Explosion range="5000.0" structuredamage="200" itemdamage="200" ballastfloradamage="200" force="5.0" severlimbsprobability="0" debris="true" decal="explosion" decalsize="1.0"
@@ -1142,7 +1215,6 @@
         </Explosion>
         <ParticleEmitter particle="underwaterexplosion" anglemin="0" anglemax="360" particleamount="3" velocitymin="0" velocitymax="0" scalemin="2" scalemax="2" />
       </StatusEffect>
-      <!-- Remove when broken -->
       <StatusEffect type="OnBroken" target="This" delay="0.01">
         <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="5000" />
         <sound file="Content/Items/Weapons/ExplosionDebris2.ogg" range="5000" />
@@ -1154,6 +1226,8 @@
       <QualityStat stattype="ExplosionDamage" value="0.1" />
     </Quality>
   </Item>
+
+  -->
 
 
   <Item identifier="bsstunbaton" category="Weapon" Tags="smallitem,weapon,stunner,gunsmith,mountableweapon" scale="0.4" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light"
@@ -1172,8 +1246,7 @@
     <InventoryIcon texture="%moddir%/Sprites/spritesheet.png" sourcerect="199,0,65,66" origin="0.5,0.5" />
     <Sprite texture="%moddir%/Sprites/spritesheet.png" sourcerect="166,0,25,218" depth="0.55" origin="0.5,0.5" />
     <Body width="170" height="30" density="20" />
-    <MeleeWeapon slots="Any,RightHand+LeftHand" aimpos="40,20" aimangle="-30" handle1="0,-20" holdangle="0" reload="0.95" range="100" combatPriority="35" msg="ItemMsgPickUpSelect"
-      preferredcontaineditems="mobilebattery">
+    <MeleeWeapon slots="Any,RightHand+LeftHand" aimpos="40,20" aimangle="-30" handle1="0,-20" holdangle="0" reload="0.95" range="100" combatPriority="35" msg="ItemMsgPickUpSelect">
       <Attack targetimpulse="5" itemdamage="1">
         <StatusEffect type="OnUse" target="UseTarget">
           <Conditional entitytype="eq Character" />
@@ -1207,9 +1280,17 @@
   </Item>
 
 
-  <Item name="Blueshield Uniform" identifier="blueshieldoutfit" category="Equipment" tags="smallitem,clothing" fireproof="false" cargocontaineridentifier="metalcrate" description="" scale="0.5"
+  <Item identifier="blueshieldoutfit" category="Equipment" tags="smallitem,clothing" fireproof="false" cargocontaineridentifier="metalcrate" scale="0.5"
     impactsoundtag="impact_soft">
     <PreferredContainer primary="crewcab" />
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.05" />
+    <Price baseprice="150" minavailable="1" requiredfaction="coalition">
+      <Price storeidentifier="merchantoutpost" minavailable="1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="1" />
+      <Price storeidentifier="merchantresearch" minavailable="1" />
+      <Price storeidentifier="merchantmilitary" minavailable="1" />
+      <Price storeidentifier="merchantmine" minavailable="1" />
+    </Price>
     <Deconstruct time="10">
       <Item identifier="organicfiber" />
     </Deconstruct>

--- a/Blueshield Job/XML/talents.xml
+++ b/Blueshield Job/XML/talents.xml
@@ -7,10 +7,10 @@
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="0,0" sheetelementsize="128,128" />
     <Description tag="talentdescription.glorytocoalition">
       <Replace tag="[requirement]" value="30" color="gui.green" />
-      <Replace tag="[bonus]" value="20" color="gui.green" />
+      <Replace tag="[bonus]" value="10" color="gui.green" />
       <Replace tag="[xpamount]" value="500" color="gui.green" />
       <Replace tag="[skillmedical]" value="skillname.medical" color="gui.green" />
-      <Replace tag="[skillweapon]" value="skillname.weapons" color="gui.green" />
+      <Replace tag="[skillweapons]" value="skillname.weapons" color="gui.green" />
       <Replace tag="[skillhelm]" value="skillname.helm" color="gui.green" />
     </Description>
     <Description tag="talentdescription.glorytocoalition2">
@@ -35,9 +35,9 @@
       </Conditions>
       <Abilities>
         <CharacterAbilityGiveExperience amount="500" />
-        <CharacterAbilityGivePermanentStat stattype="MedicalSkillBonus" statidentifier="glorytocoalition" value="15" setvalue="true" removeondeath="false" />
-        <CharacterAbilityGivePermanentStat stattype="WeaponsSkillBonus" statidentifier="glorytocoalition" value="15" setvalue="true" removeondeath="false" />
-        <CharacterAbilityGivePermanentStat stattype="HelmSkillBonus" statidentifier="glorytocoalition" value="15" setvalue="true" removeondeath="false" />
+        <CharacterAbilityGivePermanentStat stattype="MedicalSkillBonus" statidentifier="glorytocoalition" value="10" setvalue="true" removeondeath="false" />
+        <CharacterAbilityGivePermanentStat stattype="WeaponsSkillBonus" statidentifier="glorytocoalition" value="10" setvalue="true" removeondeath="false" />
+        <CharacterAbilityGivePermanentStat stattype="HelmSkillBonus" statidentifier="glorytocoalition" value="10" setvalue="true" removeondeath="false" />
       </Abilities>
     </AbilityGroupEffect>
   </Talent>
@@ -109,11 +109,11 @@
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="0,1" sheetelementsize="128,128" />
     <Description tag="talentdescription.learningtoswitchhandsrevolver">
       <Replace tag="[seconds]" value="8" color="gui.green" />
-      <Replace tag="[damage]" value="25" color="gui.green" />
+      <Replace tag="[damage]" value="30" color="gui.green" />
     </Description>
     <Description tag="talentdescription.learningtoswitchhandsstun">
       <Replace tag="[seconds]" value="8" color="gui.green" />
-      <Replace tag="[damage]" value="25" color="gui.green" />
+      <Replace tag="[damage]" value="30" color="gui.green" />
     </Description>
     <Description tag="talentdescription.reducedualwieldpenalty">
       <Replace tag="[amount]" value="50" color="gui.green" />
@@ -385,22 +385,28 @@
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="0,2" sheetelementsize="128,128" />
     <Description tag="talentdescription.mindblock" />
     <Description tag="talentdescription.unlockrecipe">
-      <Replace tag="[itemname]" value="entityname.implantmindshield" color="gui.orange" />
+      <Replace tag="[itemname]" value="entityname.implantmindshield,entityname.bsimplanter" color="gui.orange" />
     </Description>
     <AddedRecipe itemidentifier="implantmindshield" />
+    <AddedRecipe itemidentifier="bsimplanter" />
   </Talent>
 
   <Talent identifier="whysodark">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="1,2" sheetelementsize="128,128" />
     <Description tag="talentdescription.whysodark" />
     <Description tag="talentdescription.unlockrecipe">
-      <Replace tag="[itemname]" value="entityname.implantweldingshield, entityname.mufflerheadset" color="gui.orange" />
+      <Replace tag="[itemname]" value="entityname.implantweldingshield, entityname.mufflerheadset,entityname.entityname.bsimplanter" color="gui.orange" />
     </Description>
     <AddedRecipe itemidentifier="mufflerheadset" />
     <AddedRecipe itemidentifier="implantweldingshield" />
+    <AddedRecipe itemidentifier="bsimplanter" />
   </Talent>
 
+  <!-- START OF WIP -->
+  
   <!-- Проверка на количество имплантированных? -->
+
+  <!-- 
   <Talent identifier="trackerson">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="2,2" sheetelementsize="128,128" />
     <Description tag="talentdescription.trackerson">
@@ -408,8 +414,45 @@
       <Replace tag="[vitality]" value="4" color="gui.green" />
     </Description>
   </Talent>
+  -->
+
+  <Talent identifier="trackerson">
+    <Icon texture="Content/UI/TalentsIcons3.png" sheetindex="3,4" sheetelementsize="128,128"/>
+    <Description tag="talentdescription.assistantdragatfullspeed"/>
+    <Description tag="talentdescription.emergencyresponse">
+      <Replace tag="[movementspeed]" value="40" color="gui.green"/>
+    </Description>
+    <AbilityGroupInterval interval="0.9">
+      <Conditions>
+        <AbilityConditionCrewMemberUnconscious />
+      </Conditions>
+      <Abilities>
+        <CharacterAbilityApplyStatusEffects>
+          <StatusEffects>
+            <StatusEffect type="OnAbility" target="Character" disabledeltatime="true">
+              <Affliction identifier="emergencyresponse_selfbuff" amount="1.0"/>
+            </StatusEffect>
+          </StatusEffects>
+        </CharacterAbilityApplyStatusEffects>
+      </Abilities>
+    </AbilityGroupInterval>
+    <AbilityGroupInterval interval="0.9">
+      <Abilities>
+        <CharacterAbilityApplyStatusEffectsToAllies allowself="false" jobs="assistant">
+          <StatusEffects>
+            <StatusEffect type="OnAbility" target="Character" disabledeltatime="true">
+              <Affliction identifier="emergencyresponse" amount="1.0"/>
+            </StatusEffect>
+          </StatusEffects>
+        </CharacterAbilityApplyStatusEffectsToAllies>
+      </Abilities>
+    </AbilityGroupInterval>
+  </Talent>
+
 
   <!-- Проверка на количество критических? -->
+
+  <!-- 
   <Talent identifier="captainyouthere">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="3,2" sheetelementsize="128,128" />
     <Description tag="talentdescription.captainyouthere">
@@ -417,6 +460,19 @@
       <Replace tag="[speedmax]" value="40" color="gui.green" />
     </Description>
   </Talent>
+  -->
+
+  <Talent identifier="captainyouthere">
+    <Icon texture="Content/UI/TalentsIcons1.png" sheetindex="6,5" sheetelementsize="128,128"/>
+    <Description tag="talentdescription.firemanscarry"/>
+    <AbilityGroupEffect abilityeffecttype="None" >
+      <Abilities>
+        <CharacterAbilityGiveFlag flagtype="MoveNormallyWhileDragging" />
+      </Abilities>
+    </AbilityGroupEffect>
+  </Talent>
+  
+  <!-- END OF WIP -->
 
   <Talent identifier="warcrimes">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="4,2" sheetelementsize="128,128" />
@@ -450,7 +506,9 @@
   <Talent identifier="codegreen">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="0,3" sheetelementsize="128,128" />
     <Description tag="talentdescription.codegreen">
-      <Replace tag="[amount]" value="20" color="gui.green" /> /</Description>
+      <Replace tag="[fabricatorspeed]" value="50" color="gui.green" />
+      <Replace tag="[pumpenginespeed]" value="20" color="gui.green" />
+    </Description>
     <Description tag="talentdescription.codeextra" color="gui.orange">
       <Replace tag="[text]" value="talentdescription.codeextrared" color="gui.red" />
     </Description>
@@ -473,18 +531,26 @@
         <CharacterAbilityGiveItemStatToTags tags="engine" stattype="EngineSpeed" stackable="false" value="1.2" />
       </Abilities>
     </AbilityGroupInterval>
-    <AbilityGroupEffect abilityeffecttype="None">
+    <AbilityGroupInterval interval="0.9">
+      <Conditions>
+        <AbilityConditionHasAffliction afflictionidentifier="precodegreen" minimumpercentage="0.1" />
+      </Conditions>
       <Abilities>
-        <CharacterAbilityGiveItemStatToTags tags="pump" stattype="PumpSpeed" stackable="false" value="1.2" />
-        <CharacterAbilityGiveItemStatToTags tags="engine" stattype="EngineSpeed" stackable="false" value="1.2" />
+        <CharacterAbilityApplyStatusEffectsToAllies maxdistance="2000" allowself="true">
+          <StatusEffects>
+            <StatusEffect type="OnAbility" target="Character" disabledeltatime="true">
+              <Affliction identifier="codegreen" amount="1.0" />
+            </StatusEffect>
+          </StatusEffects>
+        </CharacterAbilityApplyStatusEffectsToAllies>
       </Abilities>
-    </AbilityGroupEffect>
+    </AbilityGroupInterval>
   </Talent>
 
   <Talent identifier="codeblue">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="1,3" sheetelementsize="128,128" />
     <Description tag="talentdescription.codeblue">
-      <Replace tag="[amount]" value="20" color="gui.green" />
+      <Replace tag="[amount]" value="30" color="gui.green" />
     </Description>
     <Description tag="talentdescription.codeextra" color="gui.orange">
       <Replace tag="[text]" value="talentdescription.codeextrared" color="gui.red" />
@@ -493,6 +559,20 @@
       <Replace tag="[itemname]" value="entityname.blueauthkey" color="gui.orange" />
     </Description>
     <AddedRecipe itemidentifier="blueauthkey" />
+    <AbilityGroupInterval interval="0.9">
+      <Conditions>
+        <AbilityConditionHasAffliction afflictionidentifier="precodeblue" minimumpercentage="0.1" />
+      </Conditions>
+      <Abilities>
+        <CharacterAbilityApplyStatusEffectsToAllies maxdistance="2000" allowself="true">
+          <StatusEffects>
+            <StatusEffect type="OnAbility" target="Character" disabledeltatime="true">
+              <Affliction identifier="codeblue" amount="1.0" />
+            </StatusEffect>
+          </StatusEffects>
+        </CharacterAbilityApplyStatusEffectsToAllies>
+      </Abilities>
+    </AbilityGroupInterval>
   </Talent>
 
   <Talent identifier="codered">
@@ -506,9 +586,28 @@
     <Description tag="talentdescription.unlockrecipe">
       <Replace tag="[itemname]" value="entityname.redauthkey" color="gui.orange" />
     </Description>
+    <Description tag="talentdescription.unlockrecipe">
+      <Replace tag="[itemname]" value="entityname.gygax" color="gui.orange" />
+    </Description>
+    <AddedRecipe itemidentifier="gygax" />
     <AddedRecipe itemidentifier="redauthkey" />
+    <AbilityGroupInterval interval="0.9">
+      <Conditions>
+        <AbilityConditionHasAffliction afflictionidentifier="precodered" minimumpercentage="0.1" />
+      </Conditions>
+      <Abilities>
+        <CharacterAbilityApplyStatusEffectsToAllies maxdistance="2000" allowself="true">
+          <StatusEffects>
+            <StatusEffect type="OnAbility" target="Character" disabledeltatime="true">
+              <Affliction identifier="codered" amount="1.0" />
+            </StatusEffect>
+          </StatusEffects>
+        </CharacterAbilityApplyStatusEffectsToAllies>
+      </Abilities>
+    </AbilityGroupInterval>
   </Talent>
 
+  <!--
   <Talent identifier="codegamma">
     <Icon texture="%ModDir%/Sprites/talenticons.png" sheetindex="3,3" sheetelementsize="128,128" />
     <Description tag="talentdescription.codegamma" />
@@ -534,4 +633,6 @@
     <AddedRecipe itemidentifier="flashnuke" />
     <AddedRecipe itemidentifier="deltaauthkey" />
   </Talent>
+-->
+
 </Talents>

--- a/Blueshield Job/XML/talenttrees.xml
+++ b/Blueshield Job/XML/talenttrees.xml
@@ -55,10 +55,12 @@
       <TalentOptions>
         <TalentOption identifier="codered" />
       </TalentOptions>
+      <!-- 
       <TalentOptions>
         <TalentOption identifier="codegamma" />
         <TalentOption identifier="codedelta" />
       </TalentOptions>
+      -->
     </SubTree>
   </TalentTree>
 </TalentTrees>

--- a/Blueshield Job/filelist.xml
+++ b/Blueshield Job/filelist.xml
@@ -6,5 +6,7 @@
 	<TalentTrees file="%moddir%/XML/talenttrees.xml" />
 	<Talents file="%moddir%/XML/talents.xml" />
  	<Character file="%ModDir%/Characters/Floppa/floppa.xml" />
+
 	<Text file="%moddir%/Language/english.xml" />
+	<Text file="%moddir%/Language/russian.xml" />	
 </contentpackage>


### PR DESCRIPTION
Code red and code gamma commented
Gygax moved to the red code talent and affliction, flashnuke deleted
Gygax now has a shockwave function, pushing all those around away and stunning them. Now requires a multirevolver to craft

Trackerson and captainyouthere talents commented, these now have fireman's carry and emergency response talent effects, since there's no Lua for these 2 yet.

Green and blue codes are now more powerful too
Codes no longer affect enemies, but require a living BSO to apply the afflictions. Floppa still affects all those close to it

Acid implant detonation item added for spawning near those who died with the acid implant.

Russian localization added

Minor fixes (easy to spot in comparison mode)